### PR TITLE
fix(translator): use float instead of int for temperature parameter

### DIFF
--- a/pdf2zh_next/__init__.py
+++ b/pdf2zh_next/__init__.py
@@ -30,7 +30,7 @@ from pdf2zh_next.high_level import do_translate_file_async
 
 # from pdf2zh_next.high_level import translate, translate_stream
 
-__version__ = "2.5.0"
+__version__ = "2.5.1"
 __author__ = "Byaidu, awwaawwa"
 __license__ = "AGPL-3.0"
 __maintainer__ = "awwaawwa"

--- a/pdf2zh_next/const.py
+++ b/pdf2zh_next/const.py
@@ -1,4 +1,4 @@
-__version__ = "2.5.0"
+__version__ = "2.5.1"
 __major_version__ = "2"
 __config_file_version__ = "3"
 

--- a/pdf2zh_next/main.py
+++ b/pdf2zh_next/main.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from pdf2zh_next.config import ConfigManager
 from pdf2zh_next.high_level import do_translate_file_async
 
-__version__ = "2.5.0"
+__version__ = "2.5.1"
 
 logger = logging.getLogger(__name__)
 

--- a/pdf2zh_next/translator/translator_impl/openai.py
+++ b/pdf2zh_next/translator/translator_impl/openai.py
@@ -48,7 +48,7 @@ class OpenAITranslator(BaseTranslator):
 
         if self.send_temperature and self.temperature:
             self.add_cache_impact_parameters("temperature", self.temperature)
-            self.options["temperature"] = int(self.temperature)
+            self.options["temperature"] = float(self.temperature)
         if self.send_reasoning_effort and self.reasoning_effort:
             self.add_cache_impact_parameters("reasoning_effort", self.reasoning_effort)
             self.options["reasoning_effort"] = self.reasoning_effort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf2zh-next"
-version = "2.5.0"
+version = "2.5.1"
 description = "Latex PDF Translator"
 authors = [
     { name = "awwaawwa", email = "aw@funstory.ai" },
@@ -81,7 +81,7 @@ max-line-length = 88
 
 
 [bumpver]
-current_version = "2.5.0"
+current_version = "2.5.1"
 version_pattern = "MAJOR.MINOR.PATCH[.PYTAGNUM]"
 
 [bumpver.file_patterns]


### PR DESCRIPTION
Change temperature parameter conversion from int() to float() in OpenAI translator to properly handle decimal temperature values like 0.5, 1.2 etc.