### PR TITLE
Add backward compatibility for watermark output mode

### DIFF
--- a/pdf2zh_next/config/main.py
+++ b/pdf2zh_next/config/main.py
@@ -19,7 +19,7 @@ import tomlkit
 from pydantic import BaseModel
 
 from pdf2zh_next.config.cli_env_model import CLIEnvSettingsModel
-from pdf2zh_next.config.model import SettingsModel, WatermarkOutputMode
+from pdf2zh_next.config.model import SettingsModel
 from pdf2zh_next.config.translate_engine_model import TRANSLATION_ENGINE_METADATA
 from pdf2zh_next.const import DEFAULT_CONFIG_DIR
 from pdf2zh_next.const import DEFAULT_CONFIG_FILE
@@ -43,25 +43,6 @@ class MagicDefault:
     pass
 
 
-def watermark_output_mode_converter(value):
-    """Convert watermark output mode value for backward compatibility"""
-    # First try exact match with enum names (case-insensitive)
-    for enum_member in WatermarkOutputMode:
-        if value.lower() == enum_member.name.lower():
-            return enum_member.value
-    
-    # Handle special legacy formats (case-insensitive)
-    value_lower = value.lower()
-    legacy_mappings = {
-        "nowatermark": WatermarkOutputMode.NoWatermark,
-        "watermarked": WatermarkOutputMode.Watermarked,
-        "both": WatermarkOutputMode.Both,
-    }
-    
-    if value_lower in legacy_mappings:
-        return legacy_mappings[value_lower].value
-    
-    return value
 
 
 def build_args_parser(
@@ -145,14 +126,9 @@ def build_args_parser(
                 elif arg == NoneType:
                     continue
                 else:
-                    # Use special converter for WatermarkOutputMode for backward compatibility
-                    converter_func = arg
-                    if arg == WatermarkOutputMode:
-                        converter_func = lambda x: WatermarkOutputMode(watermark_output_mode_converter(x))
-                    
                     parser.add_argument(
                         f"--{args_name}",
-                        type=converter_func,
+                        type=arg,
                         default=MagicDefault,
                         help=field_detail.description,
                     )

--- a/pdf2zh_next/config/main.py
+++ b/pdf2zh_next/config/main.py
@@ -43,8 +43,6 @@ class MagicDefault:
     pass
 
 
-
-
 def build_args_parser(
     parser: argparse.ArgumentParser | None = None,
     settings_model: type[BaseModel] | None = None,

--- a/pdf2zh_next/config/main.py
+++ b/pdf2zh_next/config/main.py
@@ -19,7 +19,7 @@ import tomlkit
 from pydantic import BaseModel
 
 from pdf2zh_next.config.cli_env_model import CLIEnvSettingsModel
-from pdf2zh_next.config.model import SettingsModel
+from pdf2zh_next.config.model import SettingsModel, WatermarkOutputMode
 from pdf2zh_next.config.translate_engine_model import TRANSLATION_ENGINE_METADATA
 from pdf2zh_next.const import DEFAULT_CONFIG_DIR
 from pdf2zh_next.const import DEFAULT_CONFIG_FILE
@@ -41,6 +41,27 @@ _no_duplicate_field_name.add("support_llm")
 
 class MagicDefault:
     pass
+
+
+def watermark_output_mode_converter(value):
+    """Convert watermark output mode value for backward compatibility"""
+    # First try exact match with enum names (case-insensitive)
+    for enum_member in WatermarkOutputMode:
+        if value.lower() == enum_member.name.lower():
+            return enum_member.value
+    
+    # Handle special legacy formats (case-insensitive)
+    value_lower = value.lower()
+    legacy_mappings = {
+        "nowatermark": WatermarkOutputMode.NoWatermark,
+        "watermarked": WatermarkOutputMode.Watermarked,
+        "both": WatermarkOutputMode.Both,
+    }
+    
+    if value_lower in legacy_mappings:
+        return legacy_mappings[value_lower].value
+    
+    return value
 
 
 def build_args_parser(
@@ -124,9 +145,14 @@ def build_args_parser(
                 elif arg == NoneType:
                     continue
                 else:
+                    # Use special converter for WatermarkOutputMode for backward compatibility
+                    converter_func = arg
+                    if arg == WatermarkOutputMode:
+                        converter_func = lambda x: WatermarkOutputMode(watermark_output_mode_converter(x))
+                    
                     parser.add_argument(
                         f"--{args_name}",
-                        type=arg,
+                        type=converter_func,
                         default=MagicDefault,
                         help=field_detail.description,
                     )

--- a/pdf2zh_next/config/model.py
+++ b/pdf2zh_next/config/model.py
@@ -4,7 +4,6 @@ import enum
 import logging
 import re
 from pathlib import Path
-from statistics import mode
 
 from pydantic import BaseModel
 from pydantic import Field
@@ -291,8 +290,10 @@ class SettingsModel(BaseModel):
                 f"Invalid watermark output mode: {watermark_output_mode}. "
                 f"Valid modes: {', '.join(watermark_output_mode_maps.keys())}"
             )
-        
-        self.pdf.watermark_output_mode = watermark_output_mode_maps[watermark_output_mode]
+
+        self.pdf.watermark_output_mode = watermark_output_mode_maps[
+            watermark_output_mode
+        ]
 
         if self.translation.qps < 1:
             raise ValueError("qps must be greater than 0")

--- a/pdf2zh_next/config/model.py
+++ b/pdf2zh_next/config/model.py
@@ -277,13 +277,12 @@ class SettingsModel(BaseModel):
             raise ValueError("max_pages_per_part must be greater than 0")
 
         # Validate and store watermark mode
-        if self.pdf.watermark_output_mode not in [
-            "watermarked",
-            "no_watermark",
-            "both"
-        ]:
+        watermark_output_modes = {'watermarked', 'no_watermark', 'both'}
+        mode = self.pdf.watermark_output_mode.lower()
+        if mode not in watermark_output_modes:
             raise ValueError(
-                f"Invalid watermark output mode: {self.pdf.watermark_output_mode}. Valid modes: ['watermarked', 'no_watermark', 'both']"
+                f"Invalid watermark output mode: {self.pdf.watermark_output_mode}. "
+                f"Valid modes: {', '.join(watermark_output_modes)}"
             )
 
         if self.translation.qps < 1:

--- a/pdf2zh_next/config/model.py
+++ b/pdf2zh_next/config/model.py
@@ -4,6 +4,7 @@ import enum
 import logging
 import re
 from pathlib import Path
+from statistics import mode
 
 from pydantic import BaseModel
 from pydantic import Field
@@ -277,13 +278,21 @@ class SettingsModel(BaseModel):
             raise ValueError("max_pages_per_part must be greater than 0")
 
         # Validate and store watermark mode
-        watermark_output_modes = {'watermarked', 'no_watermark', 'both'}
-        mode = self.pdf.watermark_output_mode.lower()
-        if mode not in watermark_output_modes:
+        watermark_output_mode_maps = {
+            "nowatermark": "no_watermark",
+            "no_watermark": "no_watermark",
+            "watermarked": "watermarked",
+            "both": "both",
+        }
+
+        watermark_output_mode = self.pdf.watermark_output_mode
+        if watermark_output_mode not in watermark_output_mode_maps:
             raise ValueError(
-                f"Invalid watermark output mode: {self.pdf.watermark_output_mode}. "
-                f"Valid modes: {', '.join(watermark_output_modes)}"
+                f"Invalid watermark output mode: {watermark_output_mode}. "
+                f"Valid modes: {', '.join(watermark_output_mode_maps.keys())}"
             )
+        
+        self.pdf.watermark_output_mode = watermark_output_mode_maps[watermark_output_mode]
 
         if self.translation.qps < 1:
             raise ValueError("qps must be greater than 0")

--- a/pdf2zh_next/config/model.py
+++ b/pdf2zh_next/config/model.py
@@ -277,12 +277,13 @@ class SettingsModel(BaseModel):
             raise ValueError("max_pages_per_part must be greater than 0")
 
         # Validate and store watermark mode
-        try:
-            WatermarkOutputMode(self.pdf.watermark_output_mode.lower())
-        except ValueError:
-            valid_modes = [mode.value for mode in WatermarkOutputMode]
+        if self.pdf.watermark_output_mode not in [
+            "watermarked",
+            "no_watermark",
+            "both"
+        ]:
             raise ValueError(
-                f"Invalid watermark output mode: {self.pdf.watermark_output_mode}. Valid modes: {valid_modes}"
+                f"Invalid watermark output mode: {self.pdf.watermark_output_mode}. Valid modes: ['watermarked', 'no_watermark', 'both']"
             )
 
         if self.translation.qps < 1:

--- a/pdf2zh_next/config/model.py
+++ b/pdf2zh_next/config/model.py
@@ -153,9 +153,9 @@ class PDFSettings(BaseModel):
     use_alternating_pages_dual: bool = Field(
         default=False, description="Use alternating pages mode for dual PDF"
     )
-    watermark_output_mode: WatermarkOutputMode = Field(
-        default=WatermarkOutputMode.Watermarked,
-        description="Watermark output mode for PDF files",
+    watermark_output_mode: str = Field(
+        default="watermarked",
+        description="Watermark output mode for PDF files (watermarked, no_watermark, or both)",
     )
     max_pages_per_part: int | None = Field(
         default=None, description="Maximum pages per part for split translation"
@@ -276,9 +276,13 @@ class SettingsModel(BaseModel):
         if self.pdf.max_pages_per_part and self.pdf.max_pages_per_part < 0:
             raise ValueError("max_pages_per_part must be greater than 0")
 
-        if self.pdf.watermark_output_mode not in WatermarkOutputMode:
+        # Validate and store watermark mode
+        try:
+            WatermarkOutputMode(self.pdf.watermark_output_mode.lower())
+        except ValueError:
+            valid_modes = [mode.value for mode in WatermarkOutputMode]
             raise ValueError(
-                f"Invalid watermark output mode: {self.pdf.watermark_output_mode}"
+                f"Invalid watermark output mode: {self.pdf.watermark_output_mode}. Valid modes: {valid_modes}"
             )
 
         if self.translation.qps < 1:

--- a/pdf2zh_next/gui.py
+++ b/pdf2zh_next/gui.py
@@ -420,14 +420,7 @@ def _build_translate_settings(
     translate_settings.pdf.use_alternating_pages_dual = use_alternating_pages_dual
 
     # Map watermark mode from UI to enum
-    if watermark_output_mode == "Watermarked":
-        from pdf2zh_next.config.model import WatermarkOutputMode
-
-        translate_settings.pdf.watermark_output_mode = WatermarkOutputMode.Watermarked
-    elif watermark_output_mode == "No Watermark":
-        from pdf2zh_next.config.model import WatermarkOutputMode
-
-        translate_settings.pdf.watermark_output_mode = WatermarkOutputMode.NoWatermark
+    translate_settings.pdf.watermark_output_mode = watermark_output_mode.lower().replace(" ", "_")
 
     # Update Advanced PDF Settings
     translate_settings.pdf.skip_clean = skip_clean

--- a/pdf2zh_next/gui.py
+++ b/pdf2zh_next/gui.py
@@ -420,7 +420,9 @@ def _build_translate_settings(
     translate_settings.pdf.use_alternating_pages_dual = use_alternating_pages_dual
 
     # Map watermark mode from UI to enum
-    translate_settings.pdf.watermark_output_mode = watermark_output_mode.lower().replace(" ", "_")
+    translate_settings.pdf.watermark_output_mode = (
+        watermark_output_mode.lower().replace(" ", "_")
+    )
 
     # Update Advanced PDF Settings
     translate_settings.pdf.skip_clean = skip_clean

--- a/pdf2zh_next/gui.py
+++ b/pdf2zh_next/gui.py
@@ -1096,7 +1096,7 @@ with gr.Blocks(
                 choices=["Watermarked", "No Watermark"],
                 label="Watermark mode",
                 value="Watermarked"
-                if settings.pdf.watermark_output_mode.value == "watermarked"
+                if settings.pdf.watermark_output_mode == "watermarked"
                 else "No Watermark",
             )
 

--- a/pdf2zh_next/high_level.py
+++ b/pdf2zh_next/high_level.py
@@ -430,7 +430,13 @@ def create_babeldoc_config(settings: SettingsModel, file: Path) -> BabelDOCConfi
         )
 
     # 设置水印模式
-    watermark_mode = BabelDOCWatermarkMode(settings.pdf.watermark_output_mode.lower())
+    watermark_output_mode = settings.pdf.watermark_output_mode.lower()
+    if watermark_output_mode == "no_watermark":
+        watermark_mode = BabelDOCWatermarkMode.NoWatermark
+    elif watermark_output_mode == "both":
+        watermark_mode = BabelDOCWatermarkMode.Both
+    else:
+        watermark_mode = BabelDOCWatermarkMode.Watermarked
 
     table_model = None
     if settings.pdf.translate_table_text:

--- a/pdf2zh_next/high_level.py
+++ b/pdf2zh_next/high_level.py
@@ -22,7 +22,6 @@ from babeldoc.main import create_progress_handler
 from rich.logging import RichHandler
 
 from pdf2zh_next.config.model import SettingsModel
-from pdf2zh_next.config.model import WatermarkOutputMode as PDF2ZHWatermarkMode
 from pdf2zh_next.translator import get_translator
 from pdf2zh_next.utils import asynchronize
 
@@ -431,12 +430,7 @@ def create_babeldoc_config(settings: SettingsModel, file: Path) -> BabelDOCConfi
         )
 
     # 设置水印模式
-    if settings.pdf.watermark_output_mode == PDF2ZHWatermarkMode.Both:
-        watermark_mode = BabelDOCWatermarkMode.Both
-    elif settings.pdf.watermark_output_mode == PDF2ZHWatermarkMode.NoWatermark:
-        watermark_mode = BabelDOCWatermarkMode.NoWatermark
-    else:
-        watermark_mode = BabelDOCWatermarkMode.Watermarked
+    watermark_mode = BabelDOCWatermarkMode(settings.pdf.watermark_output_mode.lower())
 
     table_model = None
     if settings.pdf.translate_table_text:


### PR DESCRIPTION
 - Added watermark_output_mode_converter() function to handle legacy format values
  - Supports case-insensitive matching with enum member names
  - Maps common variations (e.g., "NoWaterMark", "NoWatermark")  to correct enum values
  - Maintains backward compatibility with existing documentation examples
  - Uses enum references instead of hardcoded strings for  maintainability
  
 Current Status:
  - Documentation examples are incorrect/outdated
  eg: pdf2zh: error: argument --watermark-output-mode: invalid WatermarkOutputMode value: 'NoWatermark'
  - Users cannot successfully use the feature as documented
  - Creates friction in user adoption and experience