### PR TITLE
fix(translator): add safe checks for response.usage attributes

### DIFF
--- a/pdf2zh_next/__init__.py
+++ b/pdf2zh_next/__init__.py
@@ -30,7 +30,7 @@ from pdf2zh_next.high_level import do_translate_file_async
 
 # from pdf2zh_next.high_level import translate, translate_stream
 
-__version__ = "2.5.1"
+__version__ = "2.5.2"
 __author__ = "Byaidu, awwaawwa"
 __license__ = "AGPL-3.0"
 __maintainer__ = "awwaawwa"

--- a/pdf2zh_next/const.py
+++ b/pdf2zh_next/const.py
@@ -1,4 +1,4 @@
-__version__ = "2.5.1"
+__version__ = "2.5.2"
 __major_version__ = "2"
 __config_file_version__ = "3"
 

--- a/pdf2zh_next/main.py
+++ b/pdf2zh_next/main.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from pdf2zh_next.config import ConfigManager
 from pdf2zh_next.high_level import do_translate_file_async
 
-__version__ = "2.5.1"
+__version__ = "2.5.2"
 
 logger = logging.getLogger(__name__)
 

--- a/pdf2zh_next/translator/translator_impl/azureopenai.py
+++ b/pdf2zh_next/translator/translator_impl/azureopenai.py
@@ -50,9 +50,13 @@ class AzureOpenAITranslator(BaseTranslator):
             **self.options,
             messages=self.prompt(text),
         )
-        self.token_count.inc(response.usage.total_tokens)
-        self.prompt_token_count.inc(response.usage.prompt_tokens)
-        self.completion_token_count.inc(response.usage.completion_tokens)
+        if hasattr(response, "usage") and response.usage:
+            if hasattr(response.usage, "total_tokens"):
+                self.token_count.inc(response.usage.total_tokens)
+            if hasattr(response.usage, "prompt_tokens"):
+                self.prompt_token_count.inc(response.usage.prompt_tokens)
+            if hasattr(response.usage, "completion_tokens"):
+                self.completion_token_count.inc(response.usage.completion_tokens)
         message = response.choices[0].message.content.strip()
         message = self._remove_cot_content(message)
         return message
@@ -77,9 +81,13 @@ class AzureOpenAITranslator(BaseTranslator):
                 },
             ],
         )
-        self.token_count.inc(response.usage.total_tokens)
-        self.prompt_token_count.inc(response.usage.prompt_tokens)
-        self.completion_token_count.inc(response.usage.completion_tokens)
+        if hasattr(response, "usage") and response.usage:
+            if hasattr(response.usage, "total_tokens"):
+                self.token_count.inc(response.usage.total_tokens)
+            if hasattr(response.usage, "prompt_tokens"):
+                self.prompt_token_count.inc(response.usage.prompt_tokens)
+            if hasattr(response.usage, "completion_tokens"):
+                self.completion_token_count.inc(response.usage.completion_tokens)
         message = response.choices[0].message.content.strip()
         message = self._remove_cot_content(message)
         return message

--- a/pdf2zh_next/translator/translator_impl/openai.py
+++ b/pdf2zh_next/translator/translator_impl/openai.py
@@ -72,9 +72,13 @@ class OpenAITranslator(BaseTranslator):
             **self.options,
             messages=self.prompt(text),
         )
-        self.token_count.inc(response.usage.total_tokens)
-        self.prompt_token_count.inc(response.usage.prompt_tokens)
-        self.completion_token_count.inc(response.usage.completion_tokens)
+        if hasattr(response, "usage") and response.usage:
+            if hasattr(response.usage, "total_tokens"):
+                self.token_count.inc(response.usage.total_tokens)
+            if hasattr(response.usage, "prompt_tokens"):
+                self.prompt_token_count.inc(response.usage.prompt_tokens)
+            if hasattr(response.usage, "completion_tokens"):
+                self.completion_token_count.inc(response.usage.completion_tokens)
         message = response.choices[0].message.content.strip()
         message = self._remove_cot_content(message)
         return message
@@ -99,9 +103,13 @@ class OpenAITranslator(BaseTranslator):
                 },
             ],
         )
-        self.token_count.inc(response.usage.total_tokens)
-        self.prompt_token_count.inc(response.usage.prompt_tokens)
-        self.completion_token_count.inc(response.usage.completion_tokens)
+        if hasattr(response, "usage") and response.usage:
+            if hasattr(response.usage, "total_tokens"):
+                self.token_count.inc(response.usage.total_tokens)
+            if hasattr(response.usage, "prompt_tokens"):
+                self.prompt_token_count.inc(response.usage.prompt_tokens)
+            if hasattr(response.usage, "completion_tokens"):
+                self.completion_token_count.inc(response.usage.completion_tokens)
         message = response.choices[0].message.content.strip()
         message = self._remove_cot_content(message)
         return message

--- a/pdf2zh_next/translator/translator_impl/qwenmt.py
+++ b/pdf2zh_next/translator/translator_impl/qwenmt.py
@@ -106,9 +106,13 @@ class QwenMtTranslator(BaseTranslator):
             ],
             extra_body={"translation_options": translation_options},
         )
-        self.token_count.inc(response.usage.total_tokens)
-        self.prompt_token_count.inc(response.usage.prompt_tokens)
-        self.completion_token_count.inc(response.usage.completion_tokens)
+        if hasattr(response, "usage") and response.usage:
+            if hasattr(response.usage, "total_tokens"):
+                self.token_count.inc(response.usage.total_tokens)
+            if hasattr(response.usage, "prompt_tokens"):
+                self.prompt_token_count.inc(response.usage.prompt_tokens)
+            if hasattr(response.usage, "completion_tokens"):
+                self.completion_token_count.inc(response.usage.completion_tokens)
         message = response.choices[0].message.content.strip()
         message = self._remove_cot_content(message)
         return message

--- a/pdf2zh_next/translator/translator_impl/siliconflow.py
+++ b/pdf2zh_next/translator/translator_impl/siliconflow.py
@@ -62,9 +62,13 @@ class SiliconFlowTranslator(BaseTranslator):
             if self.send_enable_thinking_param
             else None,
         )
-        self.token_count.inc(response.usage.total_tokens)
-        self.prompt_token_count.inc(response.usage.prompt_tokens)
-        self.completion_token_count.inc(response.usage.completion_tokens)
+        if hasattr(response, "usage") and response.usage:
+            if hasattr(response.usage, "total_tokens"):
+                self.token_count.inc(response.usage.total_tokens)
+            if hasattr(response.usage, "prompt_tokens"):
+                self.prompt_token_count.inc(response.usage.prompt_tokens)
+            if hasattr(response.usage, "completion_tokens"):
+                self.completion_token_count.inc(response.usage.completion_tokens)
         message = response.choices[0].message.content.strip()
         message = self._remove_cot_content(message)
         return message
@@ -92,9 +96,13 @@ class SiliconFlowTranslator(BaseTranslator):
             if self.send_enable_thinking_param
             else None,
         )
-        self.token_count.inc(response.usage.total_tokens)
-        self.prompt_token_count.inc(response.usage.prompt_tokens)
-        self.completion_token_count.inc(response.usage.completion_tokens)
+        if hasattr(response, "usage") and response.usage:
+            if hasattr(response.usage, "total_tokens"):
+                self.token_count.inc(response.usage.total_tokens)
+            if hasattr(response.usage, "prompt_tokens"):
+                self.prompt_token_count.inc(response.usage.prompt_tokens)
+            if hasattr(response.usage, "completion_tokens"):
+                self.completion_token_count.inc(response.usage.completion_tokens)
         message = response.choices[0].message.content.strip()
         message = self._remove_cot_content(message)
         return message

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf2zh-next"
-version = "2.5.1"
+version = "2.5.2"
 description = "Latex PDF Translator"
 authors = [
     { name = "awwaawwa", email = "aw@funstory.ai" },
@@ -81,7 +81,7 @@ max-line-length = 88
 
 
 [bumpver]
-current_version = "2.5.1"
+current_version = "2.5.2"
 version_pattern = "MAJOR.MINOR.PATCH[.PYTAGNUM]"
 
 [bumpver.file_patterns]


### PR DESCRIPTION
Add defensive checks for response.usage and its attributes (total_tokens, prompt_tokens, completion_tokens) before accessing them to prevent AttributeError when these attributes don't exist in API responses.
